### PR TITLE
允许用户不指定callback；允许用户直接更新对象

### DIFF
--- a/storedb.js
+++ b/storedb.js
@@ -94,6 +94,10 @@ var storedb = function(collectionName){
 
                 }
               }
+
+              if(err == 'unknown upsert') {
+                cache[i] = upsert;
+              }
             }
           }
         }


### PR DESCRIPTION
1. 所有用到callback的地方都做了判断，如果用户不指定callback，也能正常执行而不会报错；
2. find(obj)，根据条件查询，如果callback没指定，则直接return result；
3. update(obj, obj)，用起来有点繁琐，如果我只是简单的想更新一个对象(完全替换现有对象)，现在的语法：
   db.update({"id":1}, {"$set":{"id":1,"name":"kriss"}});
   改进后如果不设置$set/$inc/$push，则默认行为是$set，例如：
   db.update({"id":1}, {"id":1,"name":"kriss"});
